### PR TITLE
Production data module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Unreleased
+
+- New som.ov.production.data.measures() entry point to obtain production measures
+- New invoice field `payment_status`
+- Invoice pdf name simplified to `[invoice_number]_[contract_cil].pdf`
+
+
 ## 0.1.0 (2024-01-23)
 
 - OV staff users

--- a/som_ov_installations/demo/giscere_instalacio_demo.xml
+++ b/som_ov_installations/demo/giscere_instalacio_demo.xml
@@ -72,6 +72,7 @@
             <field name="solicitud_ree">20201203132064</field>
             <field name="tipo">IT-00000</field>
             <field name="unitat_oferta">2</field>
+            <field name="unitat_fisica">1</field>
             <field name="data_creacio">2022-02-22</field>
         </record>
         <record id="giscere_instalacio_1" model="giscere.instalacio">
@@ -91,6 +92,7 @@
             <field name="solicitud_ree">20201203132064</field>
             <field name="tipo">IT-00001</field>
             <field name="unitat_oferta">2</field>
+            <field name="unitat_fisica">1</field>
             <field name="data_creacio">2022-02-21</field>
         </record>
         <record id="giscere_instalacio_2" model="giscere.instalacio">
@@ -110,6 +112,7 @@
             <field name="solicitud_ree">20201203132064</field>
             <field name="tipo">IT-00001</field>
             <field name="unitat_oferta">2</field>
+            <field name="unitat_fisica">1</field>
             <field name="data_creacio">2022-02-21</field>
         </record>
         <record id="giscere_instalacio_3" model="giscere.instalacio">
@@ -129,6 +132,7 @@
             <field name="solicitud_ree">20201203132064</field>
             <field name="tipo">IT-00001</field>
             <field name="unitat_oferta">2</field>
+            <field name="unitat_fisica">1</field>
             <field name="data_creacio">2022-02-21</field>
         </record>
         <record id="res_partner_bank_0" model="res.partner.bank">

--- a/som_ov_installations/som_ov_installations.py
+++ b/som_ov_installations/som_ov_installations.py
@@ -23,6 +23,21 @@ class SomOvInstallations(osv.osv_memory):
         )
     )
     def get_installations(self, cursor, uid, vat, context=None):
+        contracts = self.get_user_contracts(cursor, uid, vat, context)
+
+        return [
+            dict(
+                contract_number=contract.name,
+                installation_name=installation_name,
+            )
+                for contract, installation_name in (
+                (contract, self._get_installation_name_by_cil(cursor, uid, contract.cil.id))
+                for contract in contracts
+            )
+            if installation_name
+        ]
+
+    def get_user_contracts(self, cursor, uid, vat, context):
         if context is None:
             context = {}
 
@@ -38,19 +53,8 @@ class SomOvInstallations(osv.osv_memory):
         if not contract_ids:
             return []
 
-        contracts = polissa_obj.browse(cursor, uid, contract_ids)
+        return polissa_obj.browse(cursor, uid, contract_ids)
 
-        return [
-            dict(
-                contract_number=contract.name,
-                installation_name=installation_name,
-            )
-                for contract, installation_name in (
-                (contract, self._get_installation_name_by_cil(cursor, uid, contract.cil.id))
-                for contract in contracts
-            )
-            if installation_name
-        ]
 
     @www_entry_point(
         expected_exceptions=(

--- a/som_ov_production_data/__init__.py
+++ b/som_ov_production_data/__init__.py
@@ -1,0 +1,1 @@
+import som_ov_production_data

--- a/som_ov_production_data/__terp__.py
+++ b/som_ov_production_data/__terp__.py
@@ -15,7 +15,8 @@
     ],
     "init_xml": [],
     "demo_xml": [
-        'demo/giscere_mhcil_demo.xml',
+        "demo/giscere_mhcil_demo.xml",
+        "demo/giscere_previsio_publicada_demo.xml"
     ],
     "update_xml":[
         "security/ir.model.access.csv",

--- a/som_ov_production_data/__terp__.py
+++ b/som_ov_production_data/__terp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Production data",
+    "description": """
+        Module to interact with production data
+    """,
+    "version": "0-dev",
+    "author": "Som Energia",
+    "category": "www",
+    "depends":[
+        "giscere_mhcil",
+        "som_ov_users",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml":[
+        "security/ir.model.access.csv",
+    ],
+    "active": False,
+    "installable": True
+}

--- a/som_ov_production_data/__terp__.py
+++ b/som_ov_production_data/__terp__.py
@@ -9,10 +9,14 @@
     "category": "www",
     "depends":[
         "giscere_mhcil",
+        "giscere_polissa",
         "som_ov_users",
+        "som_ov_installations",
     ],
     "init_xml": [],
-    "demo_xml": [],
+    "demo_xml": [
+        'demo/giscere_mhcil_demo.xml',
+    ],
     "update_xml":[
         "security/ir.model.access.csv",
     ],

--- a/som_ov_production_data/demo/giscere_mhcil_demo.xml
+++ b/som_ov_production_data/demo/giscere_mhcil_demo.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="giscere_mhcil_E0_MH3" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">0</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">H3</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_E0_MHP" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">0</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">HP</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_E0_MHC" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">0</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">HC</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_E1_MHP" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">0</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2023-01-01 01:00:00.000</field>
+            <field name="timestamp">2023-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">HP</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_E1_MHC" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">0</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2023-01-01 01:00:00.000</field>
+            <field name="timestamp">2023-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">HC</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_R0" model="giscere.mhcil">
+            <field name="type_measure">R</field>
+            <field name="ae">80</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">H2</field>
+            <field name="version">0</field>
+        </record>
+        <record id="giscere_mhcil_E0" model="giscere.mhcil">
+            <field name="type_measure">E</field>
+            <field name="ae">22</field>
+            <field name="r2">0</field>
+            <field name="r3">0</field>
+            <field name="local_timestamp">2022-01-01 02:00:00.000</field>
+            <field name="timestamp">2022-01-01 01:00:00.000</field>
+            <field name="cil">ES1234000000000001JK1F001</field>
+            <field name="maturity">H3</field>
+            <field name="version">0</field>
+        </record>
+    </data>
+</openerp>

--- a/som_ov_production_data/demo/giscere_previsio_publicada_demo.xml
+++ b/som_ov_production_data/demo/giscere_previsio_publicada_demo.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="giscere_previsio_publicada_E0_MH3" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">10</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2022-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        <!--
+        <record id="giscere_previsio_publicada_E0_MHP" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">80</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2022-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        <record id="giscere_previsio_publicada_E0_MHC" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">0</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2022-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        -->
+        <record id="giscere_previsio_publicada_E1_MHP" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">100</field>
+            <field name="local_timestamp">2023-01-01 01:00:00.000</field>
+            <field name="timestamp">2023-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2023-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        <!--
+        <record id="giscere_previsio_publicada_E1_MHC" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">220</field>
+            <field name="local_timestamp">2023-01-01 01:00:00.000</field>
+            <field name="timestamp">2023-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2023-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        <record id="giscere_previsio_publicada_R0" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">380</field>
+            <field name="local_timestamp">2022-01-01 01:00:00.000</field>
+            <field name="timestamp">2022-01-01 00:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2022-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+        -->
+        <record id="giscere_previsio_publicada_E0" model="giscere.previsio.publicada">
+            <field name="utc_offset">UTC+01:0</field>
+            <field name="generacio">22</field>
+            <field name="local_timestamp">2022-01-01 02:00:00.000</field>
+            <field name="timestamp">2022-01-01 01:00:00.000</field>
+            <field name="codi_previsio">SR00000</field>
+            <field name="potencia_instalada">2000</field>
+            <field name="oferta">3-2022-01-01-2024-02-06 15:02:44</field>
+            <field name="publicada" eval="True"/>
+        </record>
+    </data>
+</openerp>

--- a/som_ov_production_data/security/ir.model.access.csv
+++ b/som_ov_production_data/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_som_ov_production_data_rcwd","som.ov.production.data","model_som_ov_production_data","base.group_user",1,1,1,1

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from collections import defaultdict
 
 from som_ov_users.decorators import www_entry_point
+from som_ov_users.exceptions import (
+    NoSuchUser,
+)
 
 
 class SomOvProductionData(osv.osv_memory):
@@ -13,7 +16,9 @@ class SomOvProductionData(osv.osv_memory):
 
     MEASURE_MATURITY_LEVELS = ('H2', 'H3', 'HP', 'HC')
 
-    @www_entry_point()
+    @www_entry_point((
+        NoSuchUser,
+    ))
     def measures(
         self, cursor, uid,
         username,

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -27,9 +27,11 @@ class SomOvProductionData(osv.osv_memory):
 
         contracts = self._get_user_contracts(cursor, uid, username, context)
         production_measures = dict(data=[
-            self._get_production_measures(cursor, contract, first_timestamp_utc, last_timestamp_utc)
+            self._get_production_measures(cursor, contract, first_timestamp_utc, last_timestamp_utc)[0][0]
             for contract in contracts
         ])
+        for contract_data in production_measures['data']:
+            contract_data['foreseen_kwh'] = [None] * len(contract_data['measure_kwh'])
 
         return production_measures
 

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -187,7 +187,11 @@ class SomOvProductionData(osv.osv_memory):
                         'contract_name', %(contract_name)s,
                         'first_timestamp_utc', %(first_timestamp_utc)s,
                         'last_timestamp_utc', %(last_timestamp_utc)s,
-                        'estimated', ARRAY_AGG(CASE WHEN type_measure IN ('E', 'M') THEN true ELSE false END ORDER BY "timestamp" ASC),
+                        'estimated', ARRAY_AGG(CASE
+                            WHEN type_measure IN ('E', 'M') THEN true
+                            WHEN type_measure IN ('R', 'L') THEN false
+                            ELSE NULL
+                        END ORDER BY "timestamp" ASC),
                         'measure_kwh', ARRAY_AGG(ae ORDER BY "timestamp" ASC),
                         'maturity', ARRAY_AGG(maturity ORDER BY "timestamp" ASC)
                     ) AS data

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -129,7 +129,7 @@ class SomOvProductionData(osv.osv_memory):
             '''
                 WITH filtered_data AS (
                     SELECT
-                        "timestamp",
+                        "timestamp" AT TIME ZONE 'UTC' AS "timestamp",
                         ae,
                         maturity,
                         type_measure
@@ -137,7 +137,7 @@ class SomOvProductionData(osv.osv_memory):
                         giscere_mhcil
                     WHERE
                         cil = %(cil)s
-                        AND "timestamp" BETWEEN %(first_timestamp_utc)s AND %(last_timestamp_utc)s
+                        AND "timestamp" AT TIME ZONE 'UTC' BETWEEN %(first_timestamp_utc)s AND %(last_timestamp_utc)s
                 ),
                 filled_data AS (
                     SELECT

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -14,8 +14,6 @@ class SomOvProductionData(osv.osv_memory):
 
     _name = "som.ov.production.data"
 
-    MEASURE_MATURITY_LEVELS = ('H2', 'H3', 'HP', 'HC')
-
     @www_entry_point((
         NoSuchUser,
     ))

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -37,7 +37,6 @@ class SomOvProductionData(osv.osv_memory):
             contract_data['foreseen_kwh'] = self._get_forecast_measures(cursor, uid, contract.cil.id, first_timestamp_utc, last_timestamp_utc, context)
             measures['data'].append(contract_data)
 
-
         return measures
 
     def _get_user_contracts(self, cursor, uid, username, context):
@@ -48,7 +47,7 @@ class SomOvProductionData(osv.osv_memory):
         installation_obj = self.pool.get('giscere.instalacio')
         installation_id = installation_obj.search(cursor, uid, [('cil', '=', cil_id)])
         installation = installation_obj.browse(cursor, uid, installation_id)[0]
-        forecast_code = installation.codi_previsio
+        forecast_code = installation.codi_previsio or "NOT_EXISTING_PLANT"
         cursor.execute(
             '''
                 WITH filtered_data AS (

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -1,14 +1,121 @@
 # -*- coding: utf-8 -*-
 from osv import osv
 
+from datetime import datetime
+from collections import defaultdict
+
 from som_ov_users.decorators import www_entry_point
+
 
 class SomOvProductionData(osv.osv_memory):
 
     _name = "som.ov.production.data"
 
+    def _get_current_date():
+        return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    DEFAULT_FIRST_TIMESTAMP = _get_current_date()
+    DEFAULT_LAST_TIMESTAMP = None
+    MEASURE_MATURITY_LEVELS = ('H2', 'H3', 'HP', 'HC')
+
     @www_entry_point()
-    def get_production_data(self, cursor, uid, cil):
-        return True
+    def measures(
+        self, cursor, uid,
+        username,
+        first_timestamp=DEFAULT_FIRST_TIMESTAMP,
+        last_timestamp=DEFAULT_LAST_TIMESTAMP,
+        context=None
+    ):
+
+        if context is None:
+            context = {}
+
+        contracts = self._get_user_contracts(cursor, uid, username, context)
+        production_measures = dict(data=[
+            self._get_production_measures(cursor, contract, first_timestamp, last_timestamp)
+            for contract in contracts
+        ])
+
+        return production_measures
+
+    def _get_user_contracts(self, cursor, uid, username, context):
+        installation_obj = self.pool.get('som.ov.installations')
+        return installation_obj.get_user_contracts(cursor, uid, username, context)
+
+    def _get_production_measures(self, cursor, contract, first_timestamp, last_timestamp):
+        cursor.execute(
+            '''
+                WITH filtered_data AS (
+                    SELECT
+                        "timestamp",
+                        ae,
+                        maturity,
+                        type_measure
+                    FROM
+                        giscere_mhcil
+                    WHERE
+                        cil = %s
+                        AND "timestamp" BETWEEN %s AND %s -- parametrized
+                    ),
+                    filled_data AS (
+                    SELECT
+                        generate_series AS "timestamp",
+                        NULL AS ae,
+                        NULL AS maturity,
+                        NULL AS type_measure
+                    FROM
+                        generate_series(
+                            %s,
+                            %s,
+                            INTERVAL '1 HOUR'
+                        )
+                    WHERE
+                        generate_series NOT IN (SELECT "timestamp" FROM filtered_data)
+                    ),
+                    final_data AS (
+                    SELECT
+                        COALESCE(fd."timestamp", fd2."timestamp") AS "timestamp",
+                        COALESCE(fd.ae, NULL) AS ae, -- Modified this line to return NULL instead of 0
+                        COALESCE(fd.maturity, fd2.maturity) AS maturity,
+                        COALESCE(fd.type_measure, fd2.type_measure) AS type_measure
+                    FROM
+                        filtered_data fd
+                    FULL JOIN
+                        filled_data fd2 ON fd."timestamp" = fd2."timestamp"
+                    ),
+                    ranked_data AS (
+                    SELECT
+                        *,
+                        RANK() OVER (PARTITION BY "timestamp" ORDER BY
+                        CASE
+                            WHEN maturity = 'H2' THEN 1
+                            WHEN maturity = 'H3' THEN 2
+                            WHEN maturity = 'HP' THEN 3
+                            WHEN maturity = 'HC' THEN 4
+                            ELSE 5
+                        END
+                        ) AS maturity_rank
+                    FROM
+                        final_data
+                    )
+                    SELECT
+                    JSON_BUILD_OBJECT(
+                        'contract_name', %s,
+                        'first_timestamp', (SELECT MIN("timestamp") FROM ranked_data),
+                        'last_timestamp', (SELECT MAX("timestamp") FROM ranked_data),
+                        'estimated', ARRAY_AGG(CASE WHEN type_measure IN ('E', 'M') THEN true ELSE false END ORDER BY "timestamp" ASC),
+                        'measured', ARRAY_AGG(ae ORDER BY "timestamp" ASC),
+                        'maturity', ARRAY_AGG(maturity ORDER BY "timestamp" ASC)
+                    ) AS data
+                    FROM
+                        ranked_data
+                    WHERE
+                    maturity_rank = 1;
+            ''',
+            (contract.cil.name, first_timestamp, last_timestamp, first_timestamp, last_timestamp, contract.name)
+        )
+
+        return cursor.fetchall()
+
 
 SomOvProductionData()

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+
+from som_ov_users.decorators import www_entry_point
+
+class SomOvProductionData(osv.osv_memory):
+
+    _name = "som.ov.production.data"
+
+    @www_entry_point()
+    def get_production_data(self, cursor, uid, cil):
+        return True
+
+SomOvProductionData()

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -11,19 +11,14 @@ class SomOvProductionData(osv.osv_memory):
 
     _name = "som.ov.production.data"
 
-    def _get_current_date():
-        return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-
-    DEFAULT_FIRST_TIMESTAMP = _get_current_date()
-    DEFAULT_LAST_TIMESTAMP = None
     MEASURE_MATURITY_LEVELS = ('H2', 'H3', 'HP', 'HC')
 
     @www_entry_point()
     def measures(
         self, cursor, uid,
         username,
-        first_timestamp=DEFAULT_FIRST_TIMESTAMP,
-        last_timestamp=DEFAULT_LAST_TIMESTAMP,
+        first_timestamp,
+        last_timestamp,
         context=None
     ):
 

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -87,7 +87,7 @@ class SomOvProductionData(osv.osv_memory):
                         filled_data fd2 ON fd."timestamp" = fd2."timestamp"
                 )
                 SELECT
-                    ARRAY_AGG(generacio ORDER BY "timestamp" ASC) AS foreseen_kwh
+                    COALESCE(ARRAY_AGG(generacio ORDER BY "timestamp" ASC), ARRAY[]::numeric[]) AS foreseen_kwh
                 FROM
                     final_data;
             ''',
@@ -192,13 +192,13 @@ class SomOvProductionData(osv.osv_memory):
                         'contract_name', %(contract_name)s,
                         'first_timestamp_utc', %(first_timestamp_utc)s,
                         'last_timestamp_utc', %(last_timestamp_utc)s,
-                        'estimated', ARRAY_AGG(CASE
+                        'estimated', COALESCE(ARRAY_AGG(CASE
                             WHEN type_measure IN ('E', 'M') THEN true
                             WHEN type_measure IN ('R', 'L') THEN false
                             ELSE NULL
-                        END ORDER BY "timestamp" ASC),
-                        'measure_kwh', ARRAY_AGG(ae ORDER BY "timestamp" ASC),
-                        'maturity', ARRAY_AGG(maturity ORDER BY "timestamp" ASC)
+                        END ORDER BY "timestamp" ASC), ARRAY[]::boolean[]),
+                        'measure_kwh', COALESCE(ARRAY_AGG(ae ORDER BY "timestamp" ASC), ARRAY[]::numeric[]),
+                        'maturity', COALESCE(ARRAY_AGG(maturity ORDER BY "timestamp" ASC), ARRAY[]::text[])
                     ) AS data
                 FROM
                     ranked_data

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -176,10 +176,10 @@ class SomOvProductionData(osv.osv_memory):
                         *,
                         RANK() OVER (PARTITION BY "timestamp" ORDER BY
                             CASE
-                                WHEN maturity = 'H2' THEN 1
-                                WHEN maturity = 'H3' THEN 2
-                                WHEN maturity = 'HP' THEN 3
-                                WHEN maturity = 'HC' THEN 4
+                                WHEN maturity = 'HC' THEN 1
+                                WHEN maturity = 'HP' THEN 2
+                                WHEN maturity = 'H3' THEN 3
+                                WHEN maturity = 'H2' THEN 4
                                 ELSE 5
                             END
                         ) AS maturity_rank

--- a/som_ov_production_data/som_ov_production_data.py
+++ b/som_ov_production_data/som_ov_production_data.py
@@ -54,10 +54,10 @@ class SomOvProductionData(osv.osv_memory):
                     FROM
                         giscere_mhcil
                     WHERE
-                        cil = %s
-                        AND "timestamp" BETWEEN %s AND %s -- parametrized
-                    ),
-                    filled_data AS (
+                        cil = %(cil)s
+                        AND "timestamp" BETWEEN %(first_timestamp)s AND %(last_timestamp)s
+                ),
+                filled_data AS (
                     SELECT
                         generate_series AS "timestamp",
                         NULL AS ae,
@@ -65,54 +65,62 @@ class SomOvProductionData(osv.osv_memory):
                         NULL AS type_measure
                     FROM
                         generate_series(
-                            %s,
-                            %s,
+                            %(first_timestamp)s,
+                            %(last_timestamp)s,
                             INTERVAL '1 HOUR'
-                        )
+                        ) generate_series
+                    LEFT JOIN
+                        filtered_data fd ON generate_series.generate_series = fd."timestamp"
                     WHERE
-                        generate_series NOT IN (SELECT "timestamp" FROM filtered_data)
-                    ),
-                    final_data AS (
+                        fd."timestamp" IS NULL
+                ),
+                final_data AS (
                     SELECT
                         COALESCE(fd."timestamp", fd2."timestamp") AS "timestamp",
-                        COALESCE(fd.ae, NULL) AS ae, -- Modified this line to return NULL instead of 0
+                        COALESCE(fd.ae, NULL) AS ae,
                         COALESCE(fd.maturity, fd2.maturity) AS maturity,
                         COALESCE(fd.type_measure, fd2.type_measure) AS type_measure
                     FROM
                         filtered_data fd
                     FULL JOIN
                         filled_data fd2 ON fd."timestamp" = fd2."timestamp"
-                    ),
-                    ranked_data AS (
+                ),
+                ranked_data AS (
                     SELECT
                         *,
                         RANK() OVER (PARTITION BY "timestamp" ORDER BY
-                        CASE
-                            WHEN maturity = 'H2' THEN 1
-                            WHEN maturity = 'H3' THEN 2
-                            WHEN maturity = 'HP' THEN 3
-                            WHEN maturity = 'HC' THEN 4
-                            ELSE 5
-                        END
+                            CASE
+                                WHEN maturity = 'H2' THEN 1
+                                WHEN maturity = 'H3' THEN 2
+                                WHEN maturity = 'HP' THEN 3
+                                WHEN maturity = 'HC' THEN 4
+                                ELSE 5
+                            END
                         ) AS maturity_rank
                     FROM
                         final_data
-                    )
-                    SELECT
+                )
+                SELECT
                     JSON_BUILD_OBJECT(
-                        'contract_name', %s,
-                        'first_timestamp', (SELECT MIN("timestamp") FROM ranked_data),
-                        'last_timestamp', (SELECT MAX("timestamp") FROM ranked_data),
+                        'contract_name', %(contract_name)s,
+                        'first_timestamp', %(first_timestamp)s,
+                        'last_timestamp', %(last_timestamp)s,
                         'estimated', ARRAY_AGG(CASE WHEN type_measure IN ('E', 'M') THEN true ELSE false END ORDER BY "timestamp" ASC),
                         'measured', ARRAY_AGG(ae ORDER BY "timestamp" ASC),
                         'maturity', ARRAY_AGG(maturity ORDER BY "timestamp" ASC)
                     ) AS data
-                    FROM
-                        ranked_data
-                    WHERE
+                FROM
+                    ranked_data
+                WHERE
                     maturity_rank = 1;
+
             ''',
-            (contract.cil.name, first_timestamp, last_timestamp, first_timestamp, last_timestamp, contract.name)
+            {
+                'cil': contract.cil.name,
+                'contract_name': contract.name,
+                'first_timestamp': first_timestamp,
+                'last_timestamp': last_timestamp
+            }
         )
 
         return cursor.fetchall()

--- a/som_ov_production_data/tests/__init__.py
+++ b/som_ov_production_data/tests/__init__.py
@@ -1,0 +1,1 @@
+from test_som_ov_production_data import *

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -34,8 +34,8 @@ class SomOvProductionDataTests(testing.OOTestCase):
                 {
                     'contract_name': '100',
                     'estimated': [False, True, False],
-                    'first_timestamp': '2022-01-01T00:00:00+00:00',
-                    'last_timestamp': '2022-01-01T02:00:00+00:00',
+                    'first_timestamp': '2022-01-01 00:00:00',
+                    'last_timestamp': '2022-01-01 02:00:00',
                     'maturity': ['H2', 'H3', None],
                     'measured': [80.0, 22.0, None]
                 },

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -31,7 +31,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
 
         expected_result = {
             'contract_name': '100',
-            'estimated': [False, True, False],
+            'estimated': [False, True, None],
             'first_timestamp_utc': '2022-01-01T00:00:00Z',
             'last_timestamp_utc': '2022-01-01T02:00:00Z',
             'maturity': ['H2', 'H3', None],

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+
+from .. import som_ov_production_data
+
+class SomOvProductionDataTests(testing.OOTestCase):
+
+    def setUp(self):
+        self.pool = self.openerp.pool
+        self.imd = self.pool.get('ir.model.data')
+
+        self.txn = Transaction().start(self.database)
+
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.maxDiff = None
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test__get_production_data(self):
+        self.assertTrue(True)

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -24,8 +24,8 @@ class SomOvProductionDataTests(testing.OOTestCase):
         result = self.production_data.measures(
             self.cursor, self.uid,
             username='ESW2796397D',
-            first_timestamp='2022-01-01 00:00:00',
-            last_timestamp='2022-01-01 02:00:00',
+            first_timestamp='2022-01-01T00:00:00Z',
+            last_timestamp='2022-01-01T02:00:00Z',
             context=None
         )
 
@@ -34,8 +34,8 @@ class SomOvProductionDataTests(testing.OOTestCase):
                 {
                     'contract_name': '100',
                     'estimated': [False, True, False],
-                    'first_timestamp': '2022-01-01 00:00:00',
-                    'last_timestamp': '2022-01-01 02:00:00',
+                    'first_timestamp': '2022-01-01T00:00:00Z',
+                    'last_timestamp': '2022-01-01T02:00:00Z',
                     'maturity': ['H2', 'H3', None],
                     'measured': [80.0, 22.0, None]
                 },

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -29,17 +29,15 @@ class SomOvProductionDataTests(testing.OOTestCase):
             context=None
         )
 
-        expected_result = [
-            (
-                {
-                    'contract_name': '100',
-                    'estimated': [False, True, False],
-                    'first_timestamp_utc': '2022-01-01T00:00:00Z',
-                    'last_timestamp_utc': '2022-01-01T02:00:00Z',
-                    'maturity': ['H2', 'H3', None],
-                    'measure_kwh': [80.0, 22.0, None]
-                },
-            )
-        ]
+        expected_result = {
+            'contract_name': '100',
+            'estimated': [False, True, False],
+            'first_timestamp_utc': '2022-01-01T00:00:00Z',
+            'last_timestamp_utc': '2022-01-01T02:00:00Z',
+            'maturity': ['H2', 'H3', None],
+            'measure_kwh': [80.0, 22.0, None],
+            'foreseen_kwh': [None, None, None],
+        }
+        self.assertNotIn('error', result, str(result))
         self.assertEqual(result['data'][0], expected_result)
         self.assertEqual(len(result['data']), 3)

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -36,7 +36,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
             'last_timestamp_utc': '2022-01-01T02:00:00Z',
             'maturity': ['H2', 'H3', None],
             'measure_kwh': [80.0, 22.0, None],
-            'foreseen_kwh': [None, None, None],
+            'foreseen_kwh': [10.0, 22.0, None],
         }
         self.assertNotIn('error', result, str(result))
         self.assertEqual(result['data'][0], expected_result)

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -138,15 +138,6 @@ class SomOvProductionDataTests(testing.OOTestCase):
             context=None
         )
 
-        expected_result = {
-            'contract_name': '100',
-            'estimated': [],
-            'first_timestamp_utc': '2018-12-31T23:00:00Z',
-            'last_timestamp_utc': '2019-01-01T02:00:00Z',
-            'maturity': [],
-            'measure_kwh': [],
-            'foreseen_kwh': [],
-        }
         self.assertNotIn('error', result, str(result))
         self.assertEqual(len(result['data']), 0)
 

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -9,6 +9,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def setUp(self):
         self.pool = self.openerp.pool
         self.imd = self.pool.get('ir.model.data')
+        self.production_data = self.pool.get('som.ov.production.data')
 
         self.txn = Transaction().start(self.database)
 
@@ -19,5 +20,26 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def tearDown(self):
         self.txn.stop()
 
-    def test__get_production_data(self):
-        self.assertTrue(True)
+    def test__measures__base(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='ESW2796397D',
+            first_timestamp='2022-01-01 00:00:00',
+            last_timestamp='2022-01-01 02:00:00',
+            context=None
+        )
+
+        expected_result = [
+            (
+                {
+                    'contract_name': '100',
+                    'estimated': [False, True, False],
+                    'first_timestamp': '2022-01-01T00:00:00+00:00',
+                    'last_timestamp': '2022-01-01T02:00:00+00:00',
+                    'maturity': ['H2', 'H3', None],
+                    'measured': [80.0, 22.0, None]
+                },
+            )
+        ]
+        self.assertEqual(result['data'][0], expected_result)
+        self.assertEqual(len(result['data']), 3)

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -24,8 +24,8 @@ class SomOvProductionDataTests(testing.OOTestCase):
         result = self.production_data.measures(
             self.cursor, self.uid,
             username='ESW2796397D',
-            first_timestamp='2022-01-01T00:00:00Z',
-            last_timestamp='2022-01-01T02:00:00Z',
+            first_timestamp_utc='2022-01-01T00:00:00Z',
+            last_timestamp_utc='2022-01-01T02:00:00Z',
             context=None
         )
 
@@ -34,10 +34,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
                 {
                     'contract_name': '100',
                     'estimated': [False, True, False],
-                    'first_timestamp': '2022-01-01T00:00:00Z',
-                    'last_timestamp': '2022-01-01T02:00:00Z',
+                    'first_timestamp_utc': '2022-01-01T00:00:00Z',
+                    'last_timestamp_utc': '2022-01-01T02:00:00Z',
                     'maturity': ['H2', 'H3', None],
-                    'measured': [80.0, 22.0, None]
+                    'measure_kwh': [80.0, 22.0, None]
                 },
             )
         ]

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -25,19 +25,58 @@ class SomOvProductionDataTests(testing.OOTestCase):
             self.cursor, self.uid,
             username='ESW2796397D',
             first_timestamp_utc='2022-01-01T00:00:00Z',
+            last_timestamp_utc='2022-01-01T01:00:00Z',
+            context=None
+        )
+
+        expected_result = {
+            'contract_name': '100',
+            'estimated': [False, True],
+            'first_timestamp_utc': '2022-01-01T00:00:00Z',
+            'last_timestamp_utc': '2022-01-01T01:00:00Z',
+            'maturity': ['H2', 'H3'],
+            'measure_kwh': [80.0, 22.0],
+            'foreseen_kwh': [10.0, 22.0],
+        }
+        self.assertNotIn('error', result, str(result))
+        self.assertEqual(result['data'][0], expected_result)
+        self.assertEqual(len(result['data']), 3)
+
+
+    def test__measures__gaps_filled_with_none(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='ESW2796397D',
+            first_timestamp_utc='2021-12-31T23:00:00Z',
             last_timestamp_utc='2022-01-01T02:00:00Z',
             context=None
         )
 
         expected_result = {
             'contract_name': '100',
-            'estimated': [False, True, None],
-            'first_timestamp_utc': '2022-01-01T00:00:00Z',
+            'estimated': [None, False, True, None],
+            'first_timestamp_utc': '2021-12-31T23:00:00Z',
             'last_timestamp_utc': '2022-01-01T02:00:00Z',
-            'maturity': ['H2', 'H3', None],
-            'measure_kwh': [80.0, 22.0, None],
-            'foreseen_kwh': [10.0, 22.0, None],
+            'maturity': [None, 'H2', 'H3', None],
+            'measure_kwh': [None, 80.0, 22.0, None],
+            'foreseen_kwh': [None, 10.0, 22.0, None],
         }
         self.assertNotIn('error', result, str(result))
         self.assertEqual(result['data'][0], expected_result)
         self.assertEqual(len(result['data']), 3)
+
+    def test__measures__no_such_user(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='username_not_exists',
+            first_timestamp_utc='2021-12-31T23:00:00Z',
+            last_timestamp_utc='2022-01-01T02:00:00Z',
+            context=None
+        )
+
+        self.assertEqual(result, dict(
+            code='NoSuchUser',
+            error='User does not exist',
+            trace=result.get('trace', 'NO TRACE AVAILABLE'),
+        ))
+

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -178,3 +178,17 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertNotIn('error', result, str(result))
         self.assertEqual(result['data'][0], expected_result)
 
+    def test__mesasures__time_series(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='ESW2796397D',
+            first_timestamp_utc='2020-01-01T00:00:00Z',
+            last_timestamp_utc='2024-01-01T00:00:00Z',
+            context=None
+        )
+
+        expected_timestamp_range_total_hours_ = 35065
+        self.assertNotIn('error', result, str(result))
+        self.assertEqual(len(result['data'][0]['estimated']), expected_timestamp_range_total_hours_)
+        self.assertEqual(len(result['data'][0]['measure_kwh']), expected_timestamp_range_total_hours_)
+        self.assertEqual(len(result['data'][0]['foreseen_kwh']), expected_timestamp_range_total_hours_)

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -4,7 +4,11 @@ from destral.transaction import Transaction
 
 from .. import som_ov_production_data
 
+
 class SomOvProductionDataTests(testing.OOTestCase):
+
+    base_username = 'ESW2796397D'
+    username_without_contracts = 'ES36464471H'
 
     def setUp(self):
         self.pool = self.openerp.pool
@@ -28,7 +32,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__measures__base(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2022-01-01T00:00:00Z',
             last_timestamp_utc='2022-01-01T01:00:00Z',
             context=None
@@ -51,7 +55,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__measures__gaps_filled_with_none(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2021-12-31T23:00:00Z',
             last_timestamp_utc='2022-01-01T02:00:00Z',
             context=None
@@ -88,7 +92,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__measures__no_data(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2018-12-31T23:00:00Z',
             last_timestamp_utc='2019-01-01T02:00:00Z',
             context=None
@@ -110,7 +114,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__measures__crossed_dates(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2018-12-31T23:00:00Z',
             last_timestamp_utc='2016-01-01T02:00:00Z',
             context=None
@@ -132,7 +136,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__measures__user_without_contracts(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ES36464471H',
+            username=self.username_without_contracts,
             first_timestamp_utc='2021-12-31T23:00:00Z',
             last_timestamp_utc='2022-01-01T02:00:00Z',
             context=None
@@ -151,7 +155,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
 
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2022-01-01T00:00:00Z',
             last_timestamp_utc='2022-01-01T01:00:00Z',
             context=None
@@ -172,7 +176,7 @@ class SomOvProductionDataTests(testing.OOTestCase):
     def test__mesasures__time_series(self):
         result = self.production_data.measures(
             self.cursor, self.uid,
-            username='ESW2796397D',
+            username=self.base_username,
             first_timestamp_utc='2020-01-01T00:00:00Z',
             last_timestamp_utc='2024-01-01T00:00:00Z',
             context=None

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -80,3 +80,47 @@ class SomOvProductionDataTests(testing.OOTestCase):
             trace=result.get('trace', 'NO TRACE AVAILABLE'),
         ))
 
+    def test__measures__no_data(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='ESW2796397D',
+            first_timestamp_utc='2018-12-31T23:00:00Z',
+            last_timestamp_utc='2019-01-01T02:00:00Z',
+            context=None
+        )
+
+        expected_result = {
+            'contract_name': '100',
+            'estimated': [None, None, None, None],
+            'first_timestamp_utc': '2018-12-31T23:00:00Z',
+            'last_timestamp_utc': '2019-01-01T02:00:00Z',
+            'maturity': [None, None, None, None],
+            'measure_kwh': [None, None, None, None],
+            'foreseen_kwh': [None, None, None, None],
+        }
+        self.assertNotIn('error', result, str(result))
+        self.assertEqual(result['data'][0], expected_result)
+        self.assertEqual(len(result['data']), 3)
+
+    def test__measures__crossed_dates(self):
+        result = self.production_data.measures(
+            self.cursor, self.uid,
+            username='ESW2796397D',
+            first_timestamp_utc='2018-12-31T23:00:00Z',
+            last_timestamp_utc='2016-01-01T02:00:00Z',
+            context=None
+        )
+
+        expected_result = {
+            'contract_name': '100',
+            'estimated': [],
+            'first_timestamp_utc': '2018-12-31T23:00:00Z',
+            'last_timestamp_utc': '2016-01-01T02:00:00Z',
+            'maturity': [],
+            'measure_kwh': [],
+            'foreseen_kwh': [],
+        }
+        self.assertNotIn('error', result, str(result))
+        self.assertEqual(result['data'][0], expected_result)
+        self.assertEqual(len(result['data']), 3)
+

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -30,12 +30,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         )[1]
 
     def test__measures__base(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2022-01-01T00:00:00Z',
             last_timestamp_utc='2022-01-01T01:00:00Z',
-            context=None
         )
 
         expected_result = {
@@ -51,14 +49,11 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(result['data'][0], expected_result)
         self.assertEqual(len(result['data']), 3)
 
-
     def test__measures__gaps_filled_with_none(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2021-12-31T23:00:00Z',
             last_timestamp_utc='2022-01-01T02:00:00Z',
-            context=None
         )
 
         expected_result = {
@@ -75,12 +70,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(len(result['data']), 3)
 
     def test__measures__no_such_user(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username='username_not_exists',
-            first_timestamp_utc='2021-12-31T23:00:00Z',
-            last_timestamp_utc='2022-01-01T02:00:00Z',
-            context=None
+            first_timestamp_utc='2022-01-01T00:00:00Z',
+            last_timestamp_utc='2022-01-01T01:00:00Z',
         )
 
         self.assertEqual(result, dict(
@@ -90,12 +83,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         ))
 
     def test__measures__no_data(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2018-12-31T23:00:00Z',
             last_timestamp_utc='2019-01-01T02:00:00Z',
-            context=None
         )
 
         expected_result = {
@@ -112,12 +103,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(len(result['data']), 3)
 
     def test__measures__crossed_dates(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2018-12-31T23:00:00Z',
-            last_timestamp_utc='2016-01-01T02:00:00Z',
-            context=None
+            last_timestamp_utc='2016-01-01T02:00:00Z'
         )
 
         expected_result = {
@@ -134,12 +123,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(len(result['data']), 3)
 
     def test__measures__user_without_contracts(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.username_without_contracts,
-            first_timestamp_utc='2021-12-31T23:00:00Z',
-            last_timestamp_utc='2022-01-01T02:00:00Z',
-            context=None
+            first_timestamp_utc='2022-01-01T00:00:00Z',
+            last_timestamp_utc='2022-01-01T01:00:00Z',
         )
 
         self.assertNotIn('error', result, str(result))
@@ -153,12 +140,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         )
         installation_obj.write(self.cursor, self.uid, installation_id, dict(codi_previsio=None))
 
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2022-01-01T00:00:00Z',
             last_timestamp_utc='2022-01-01T01:00:00Z',
-            context=None
         )
 
         expected_result = {
@@ -174,12 +159,10 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(result['data'][0], expected_result)
 
     def test__mesasures__time_series(self):
-        result = self.production_data.measures(
-            self.cursor, self.uid,
+        result = self._sut(
             username=self.base_username,
             first_timestamp_utc='2020-01-01T00:00:00Z',
             last_timestamp_utc='2024-01-01T00:00:00Z',
-            context=None
         )
 
         expected_timestamp_range_total_hours_ = 35065
@@ -187,3 +170,12 @@ class SomOvProductionDataTests(testing.OOTestCase):
         self.assertEqual(len(result['data'][0]['estimated']), expected_timestamp_range_total_hours_)
         self.assertEqual(len(result['data'][0]['measure_kwh']), expected_timestamp_range_total_hours_)
         self.assertEqual(len(result['data'][0]['foreseen_kwh']), expected_timestamp_range_total_hours_)
+
+    def _sut(self, username, first_timestamp_utc, last_timestamp_utc):
+        return self.production_data.measures(
+            self.cursor, self.uid,
+            username=username,
+            first_timestamp_utc=first_timestamp_utc,
+            last_timestamp_utc=last_timestamp_utc,
+            context=None
+        )

--- a/som_ov_production_data/tests/test_som_ov_production_data.py
+++ b/som_ov_production_data/tests/test_som_ov_production_data.py
@@ -38,11 +38,11 @@ class SomOvProductionDataTests(testing.OOTestCase):
 
         expected_result = {
             'contract_name': '100',
-            'estimated': [False, True],
+            'estimated': [True, True],
             'first_timestamp_utc': '2022-01-01T00:00:00Z',
             'last_timestamp_utc': '2022-01-01T01:00:00Z',
-            'maturity': ['H2', 'H3'],
-            'measure_kwh': [80.0, 22.0],
+            'maturity': ['HC', 'H3'],
+            'measure_kwh': [0.0, 22.0],
             'foreseen_kwh': [10.0, 22.0],
         }
         self.assertNotIn('error', result, str(result))
@@ -58,11 +58,11 @@ class SomOvProductionDataTests(testing.OOTestCase):
 
         expected_result = {
             'contract_name': '100',
-            'estimated': [None, False, True, None],
+            'estimated': [None, True, True, None],
             'first_timestamp_utc': '2021-12-31T23:00:00Z',
             'last_timestamp_utc': '2022-01-01T02:00:00Z',
-            'maturity': [None, 'H2', 'H3', None],
-            'measure_kwh': [None, 80.0, 22.0, None],
+            'maturity': [None, 'HC', 'H3', None],
+            'measure_kwh': [None, 0.0, 22.0, None],
             'foreseen_kwh': [None, 10.0, 22.0, None],
         }
         self.assertNotIn('error', result, str(result))
@@ -148,11 +148,11 @@ class SomOvProductionDataTests(testing.OOTestCase):
 
         expected_result = {
             'contract_name': '100',
-            'estimated': [False, True],
+            'estimated': [True, True],
             'first_timestamp_utc': '2022-01-01T00:00:00Z',
             'last_timestamp_utc': '2022-01-01T01:00:00Z',
-            'maturity': ['H2', 'H3'],
-            'measure_kwh': [80.0, 22.0],
+            'maturity': ['HC', 'H3'],
+            'measure_kwh': [0.0, 22.0],
             'foreseen_kwh': [None, None], # THIS CHANGES
         }
         self.assertNotIn('error', result, str(result))


### PR DESCRIPTION
## Description

New module to interact with production data

## Changes

- New endpoint to retrieve production and forecasting data

## Observations

- Data acquisition is done in raw sql instead of orm, motivations:
  - Performance: even though sql adds complexity due to adding business logic, is faster than acquire the information via orm and, manipulate data structures from Python, which strategy is not without complexity.

## How to check the new features

```
./dodestral.sh -m som_ov_production_data
```

## Deploy notes

* Don't forget to execute `./tools/link_addons.sh` script since is a new module.
* Drop `destral` database if necessary.
