### PR TITLE
Hide invoices emitted beyond a given date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Hide invoices emitted beyond a given date
 - Extract liquidation information from invoice line
 - Retrieve production data for a single contract
 

--- a/som_ov_invoices/som_ov_invoices.py
+++ b/som_ov_invoices/som_ov_invoices.py
@@ -26,14 +26,21 @@ class SomOvInvoices(osv.osv_memory):
     }
 
     COMPLEMENTARY_LIQUIDATION = 'COMPLEMENTARY'
-
+    OLDEST_INVOICE_EMISSION_DATE = '2024-05-16'
 
     @www_entry_point(
         expected_exceptions=(
             NoSuchUser,
         )
     )
-    def get_invoices(self, cursor, uid, vat, context=None):
+    def get_invoices(
+            self,
+            cursor,
+            uid,
+            vat,
+            oldest_date=OLDEST_INVOICE_EMISSION_DATE,
+            context=None,
+    ):
         if context is None:
             context = {}
 
@@ -45,6 +52,10 @@ class SomOvInvoices(osv.osv_memory):
             ('partner_id', '=', partner.id),
             ('state', 'in', ['open', 'paid']),
         ]
+        if oldest_date:
+            search_params.append(
+                ('date_invoice', '>=', oldest_date),
+            )
 
         invoice_ids = invoice_obj.search(cursor, uid, search_params)
 
@@ -197,5 +208,6 @@ class SomOvInvoices(osv.osv_memory):
             if extra_line.type_extra == 'retribution':
                 return self.extract_retribution_liquidation_description(extra_line)
         return None
+
 
 SomOvInvoices()

--- a/som_ov_users/data/email_template_data.xml
+++ b/som_ov_users/data/email_template_data.xml
@@ -25,7 +25,7 @@
             <field name="lang">${object.lang}</field>
             <field eval="0" name="send_on_write"/>
             <field name="def_bcc"></field>
-            <field name="enforce_from_account" model="poweremail.core_accounts" search="[('name','=', 'Som Energia - Representació')]"/>
+            <field name="enforce_from_account" ref="representa_from_email"/>
             <field name="def_body_text"><![CDATA[
                 <!doctype html>
                 <html>


### PR DESCRIPTION
## Description

- Hide invoices emitted beyond a given date

## Changes

- Add constant to define the limit date
- `get_invoices` has been parameterized with the limit date
- Add limit date to the search domain

## Checklist

Justify any unchecked point:

- [X] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
N/A
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation
N/A

## Observations

- A pending change has to be done in order to set the proper date defined by domain team.

## Please, review

- Code follows ERP team standards

## How to check the new features
### Test
```bash
./dodestral.sh -m som_ov_invoices --no-requirements
```

## Deploy notes
N/A

